### PR TITLE
django.contrib.site, sitemaps 사용및 사이트맵 구현

### DIFF
--- a/apps/posts/models/post.py
+++ b/apps/posts/models/post.py
@@ -41,7 +41,7 @@ class Post(TimeStampedModel):
         ordering = ["-created"]
 
     objects = models.Manager()
-    published = PublishedManager()
+    published_posts = PublishedManager()
     pages = PageManager()
 
     thumbnail = UUIDImageField(

--- a/apps/posts/sitemaps.py
+++ b/apps/posts/sitemaps.py
@@ -1,0 +1,49 @@
+from django.contrib.sitemaps import Sitemap
+from django.urls import reverse
+
+from .models import Category, Post
+
+
+class PostSitemap(Sitemap):
+    changefreq = "daily"
+    languages = ["ko_KR"]
+    priority = 0.7
+
+    def items(self):
+        return Post.published_posts.filter(status__in=Post.public_on_category_status())
+
+    def lastmod(self, post: Post):
+        return post.updated
+
+
+class PageSitemap(Sitemap):
+    changefreq = "daily"
+    languages = ["ko_KR"]
+    priority = 0.7
+
+    def items(self):
+        return Post.pages.all()
+
+    def lastmod(self, post: Post):
+        return post.updated
+
+
+class CategorySitemap(Sitemap):
+    changefreq = "weekly"
+    languages = ["ko_KR"]
+    priority = 0.5
+
+    def items(self):
+        return Category.objects.all()
+
+
+class PostsStaticSitemap(Sitemap):
+    changefreq = "never"
+    languages = ["ko_KR"]
+    priority = 0.3
+
+    def items(self):
+        return ["apps.posts:post_list"]
+
+    def location(self, item):
+        return reverse(item)

--- a/apps/posts/views.py
+++ b/apps/posts/views.py
@@ -10,7 +10,7 @@ class PostDetailView(DetailView):
 
 class PostListView(ListView):
     def get_queryset(self):
-        queryset = Post.published.select_related("category")
+        queryset = Post.published_posts.select_related("category")
         return queryset
 
     def get_context_data(self, **kwargs):

--- a/config/settings/django.py
+++ b/config/settings/django.py
@@ -13,6 +13,8 @@ DJANGO_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django.contrib.sites",
+    "django.contrib.sitemaps",
 ]
 THIRDPARTY_APPS = [
     "markdownx",
@@ -111,3 +113,5 @@ STATICFILES_DIRS = [
 
 MEDIA_ROOT = os.path.join(BASE_DIR, "files/")
 MEDIA_URL = "/files/"
+
+SITE_ID = 1

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,13 +1,34 @@
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
+from django.contrib.sitemaps.views import sitemap
 from django.urls import include, path
+
+from apps.posts.sitemaps import (
+    CategorySitemap,
+    PageSitemap,
+    PostSitemap,
+    PostsStaticSitemap,
+)
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("", include("apps.posts.urls")),
     path("", include("apps.main.urls")),
     path("", include("apps.core.urls")),
+    path(
+        "sitemap.xml",
+        sitemap,
+        {
+            "sitemaps": {
+                "posts": PostSitemap,
+                "pages": PageSitemap,
+                "categories": CategorySitemap,
+                "posts_static": PostsStaticSitemap,
+            }
+        },
+        name="django.contrib.sitemaps.views.sitemap",
+    ),
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
close #4 

사이트맵 구현

- django.contrib.site, django.contrib.sitemaps App 추가
- posts, page, category 사이트맵 항목 추가 
